### PR TITLE
Add support for private endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ enable auth methods at any location, please update your API calls accordingly.
 
 ## Configure
 
+Configures the credentials and parameters required for the plugin to perform API calls to IBM Cloud IAM and User Management. These
+credentials will be used to verify user account and service ID account access and access group membership. The user account or
+service ID providing the API key needs to have the following permissions:
+
+* `Viewer` on `Access Groups Service`
+* `Viewer` on `IAM Identity Service` 
+* `Viewer` on `User Management Service` 
+
 Configures the auth method and must be done before authentication can succeed.
 
 | Method   | Path |
@@ -368,15 +376,12 @@ $ make dev
 For local development, use Vault's "dev" mode for fast setup:
 
 ```sh
-$ vault server -dev -dev-plugin-dir="$(pwd)/bin"
+$ vault server -dev -config vault.hcl
 ```
 
-The plugin will automatically be added to the catalog with the name
-"vault-plugin-auth-ibmcloud". Run the following command to enable this new auth
-method as a plugin:
-
-```sh
-$ vault auth enable -plugin-name="vault-plugin-auth-ibmcloud" -path="ibmcloud" plugin
-Success! Enabled vault-plugin-auth-ibmcloud auth method at: ibmcloud/
+Where vault.hcl configures the plugin directory like this:
 ```
- 
+plugin_directory = "./plugins"
+```
+
+Follow the setup instructions to copy, register, and enable the plugin.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin allows for various IBM Cloud entities to authenticate with Vault.
 User accounts or service IDs can sign in using an IBM Cloud IAM access token or API key.
 
 ## Versions
-This version of the plugin was tested with Vault 1.6.0.
+This version of the plugin was tested with Vault 1.9.4.
 
 ## Installation
 
@@ -51,6 +51,10 @@ Configures the auth method and must be done before authentication can succeed.
 membership for the all the access groups bound to the plugin's roles.
 * `account_id (string: <required>)` - An IBM Cloud account ID. The auth method will only authenticate users or service IDs that
 have access to this account.
+* `iam_endpoint (string: <optional>)` - The custom or private IAM endpoint. For example `https://private.iam.cloud.ibm.com`.
+If unspecified the public endpoint, `https://iam.cloud.ibm.com`, is used.
+* `user_management_endpoint (string: <optional>)` - The custom or private user management endpoint. For example `https://private.user-management.cloud.ibm.com`.
+If unspecified the public endpoint, `https://user-management.cloud.ibm.com`, is used.
 
 ### Sample Payload
 
@@ -90,7 +94,9 @@ $ curl \
 {
   "data": {
     "api_key": "<redacted>",
-    "account_id": "abd85726cbd..."
+    "account_id": "abd85726cbd...",
+    "iam_endpoint": "https://iam.cloud.ibm.com",
+    "user_management_endpoint": "https://user-management.cloud.ibm.com",
   },
   "...": "..."
 

--- a/backend_test.go
+++ b/backend_test.go
@@ -2,17 +2,14 @@ package ibmcloudauth
 
 import (
 	"context"
-	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vault/sdk/logical"
 	"testing"
 	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/logical"
 )
 
 func testBackend(tb testing.TB) (*ibmCloudAuthBackend, logical.Storage) {
-	return testBackendWithMock(tb, nil)
-}
-
-func testBackendWithMock(tb testing.TB, iamH iamHelper) (*ibmCloudAuthBackend, logical.Storage) {
 	tb.Helper()
 
 	defaultLeaseTTLVal := time.Hour * 12
@@ -29,10 +26,6 @@ func testBackendWithMock(tb testing.TB, iamH iamHelper) (*ibmCloudAuthBackend, l
 	err := b.Setup(context.Background(), config)
 	if err != nil {
 		tb.Fatalf("unable to create backend: %v", err)
-	}
-	if iamH != nil {
-		b.iamHelper.Cleanup()
-		b.iamHelper = iamH
 	}
 	return b, config.StorageView
 }

--- a/constants.go
+++ b/constants.go
@@ -1,9 +1,9 @@
 package ibmcloudauth
 
 const (
-	iamEndpointFieldDefault    = "https://iam.cloud.ibm.com"
-	iamIdentityEndpointDefault = "https://iam.cloud.ibm.com/identity"
-	userMgmtEndpointDefault    = "https://user-management.cloud.ibm.com/"
+	iamEndpointFieldDefault = "https://iam.cloud.ibm.com"
+	openIDIssuer            = "https://iam.cloud.ibm.com/identity"
+	userMgmtEndpointDefault = "https://user-management.cloud.ibm.com"
 )
 
 // IAM API paths
@@ -11,6 +11,8 @@ const (
 	accessGroupMembershipCheck = "/v2/groups/%s/members/%s"
 	serviceIDDetails           = "/v1/serviceids/%s"
 	getUserProfile             = "/v2/accounts/%s/users/%s"
+	identityToken              = "/identity/token"
+	identity                   = "/identity"
 )
 
 //Number of minutes to renew the admin token before expiration
@@ -18,14 +20,16 @@ const adminTokenRenewBeforeExpirationMinutes = 5
 
 // request & response fields
 const (
-	accountIDField       = "account_id"
-	identifierField      = "identifier"
-	roleField            = "role"
-	apiKeyField          = "api_key"
-	tokenKeyField        = "token"
-	redacted             = "<redacted>"
-	iamIDField           = "IAM_ID"
-	subjectField         = "subject"
-	subjectTypeField     = "sub_type"
-	serviceIDSubjectType = "ServiceId"
+	accountIDField              = "account_id"
+	iamEndpointField            = "iam_endpoint"
+	userManagementEndpointField = "user_management_endpoint"
+	identifierField             = "identifier"
+	roleField                   = "role"
+	apiKeyField                 = "api_key"
+	tokenKeyField               = "token"
+	redacted                    = "<redacted>"
+	iamIDField                  = "IAM_ID"
+	subjectField                = "subject"
+	subjectTypeField            = "sub_type"
+	serviceIDSubjectType        = "ServiceId"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module vault-plugin-auth-ibmcloud
 go 1.16
 
 require (
-	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/golang/mock v1.4.4
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
@@ -11,7 +11,6 @@ require (
 	github.com/hashicorp/go-version v1.2.1 // indirect
 	github.com/hashicorp/vault/api v1.0.5-0.20200527182800-ad90e0b39d2f
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200527182800-ad90e0b39d2f
-	github.com/pquerna/cachecontrol v0.0.0-20200819021114-67c6ae64274f // indirect
 	github.com/stretchr/testify v1.6.1
 	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=
@@ -13,6 +14,8 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
 github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
+github.com/coreos/go-oidc/v3 v3.1.0 h1:6avEvcdvTa1qYsOZ6I5PRkSYHzpTNWgKYmaJfaYbrRw=
+github.com/coreos/go-oidc/v3 v3.1.0/go.mod h1:rEJ/idjfUyfkBit1eI1fvyr+64/g9dcKpAm8MJMesvo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -139,6 +142,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
@@ -153,12 +157,17 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 h1:fHDIZ2oxGnUZRN6WgWFCbYBjH9uqVPRCUVUDhs0wnbA=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200505041828-1ed23360d12c h1:zJ0mtu4jCalhKg6Oaukv6iIkb+cOvDrajDH9DH46Q4M=
+golang.org/x/net v0.0.0-20200505041828-1ed23360d12c/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -171,6 +180,8 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
@@ -212,6 +223,9 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
+gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/helpers.go
+++ b/helpers.go
@@ -6,14 +6,6 @@ import (
 	"net/http"
 )
 
-func getURL(endpoint, path string, pathReplacements ...string) string {
-	pathSubs := make([]interface{}, len(pathReplacements))
-	for i, v := range pathReplacements {
-		pathSubs[i] = v
-	}
-	return fmt.Sprintf("%s%s", endpoint, fmt.Sprintf(path, pathSubs...))
-}
-
 func httpRequest(client *http.Client, r *http.Request) ([]byte, int, error) {
 	resp, err := client.Do(r)
 	if err != nil {

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -6,35 +6,102 @@ package ibmcloudauth
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	logical "github.com/hashicorp/vault/sdk/logical"
-	reflect "reflect"
 )
 
-// MockiamHelper is a mock of iamHelper interface
+// MockiamHelper is a mock of iamHelper interface.
 type MockiamHelper struct {
 	ctrl     *gomock.Controller
 	recorder *MockiamHelperMockRecorder
 }
 
-// MockiamHelperMockRecorder is the mock recorder for MockiamHelper
+// MockiamHelperMockRecorder is the mock recorder for MockiamHelper.
 type MockiamHelperMockRecorder struct {
 	mock *MockiamHelper
 }
 
-// NewMockiamHelper creates a new mock instance
+// NewMockiamHelper creates a new mock instance.
 func NewMockiamHelper(ctrl *gomock.Controller) *MockiamHelper {
 	mock := &MockiamHelper{ctrl: ctrl}
 	mock.recorder = &MockiamHelperMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockiamHelper) EXPECT() *MockiamHelperMockRecorder {
 	return m.recorder
 }
 
-// ObtainToken mocks base method
+// CheckGroupMembership mocks base method.
+func (m *MockiamHelper) CheckGroupMembership(groupID, iamID, iamToken string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckGroupMembership", groupID, iamID, iamToken)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckGroupMembership indicates an expected call of CheckGroupMembership.
+func (mr *MockiamHelperMockRecorder) CheckGroupMembership(groupID, iamID, iamToken interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckGroupMembership", reflect.TypeOf((*MockiamHelper)(nil).CheckGroupMembership), groupID, iamID, iamToken)
+}
+
+// CheckServiceIDAccount mocks base method.
+func (m *MockiamHelper) CheckServiceIDAccount(iamToken, identifier, accountID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckServiceIDAccount", iamToken, identifier, accountID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckServiceIDAccount indicates an expected call of CheckServiceIDAccount.
+func (mr *MockiamHelperMockRecorder) CheckServiceIDAccount(iamToken, identifier, accountID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckServiceIDAccount", reflect.TypeOf((*MockiamHelper)(nil).CheckServiceIDAccount), iamToken, identifier, accountID)
+}
+
+// CheckUserIDAccount mocks base method.
+func (m *MockiamHelper) CheckUserIDAccount(iamToken, iamID, accountID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckUserIDAccount", iamToken, iamID, accountID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckUserIDAccount indicates an expected call of CheckUserIDAccount.
+func (mr *MockiamHelperMockRecorder) CheckUserIDAccount(iamToken, iamID, accountID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckUserIDAccount", reflect.TypeOf((*MockiamHelper)(nil).CheckUserIDAccount), iamToken, iamID, accountID)
+}
+
+// Cleanup mocks base method.
+func (m *MockiamHelper) Cleanup() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Cleanup")
+}
+
+// Cleanup indicates an expected call of Cleanup.
+func (mr *MockiamHelperMockRecorder) Cleanup() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockiamHelper)(nil).Cleanup))
+}
+
+// Init mocks base method.
+func (m *MockiamHelper) Init(iamEndpoint, userManagementEndpoint string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Init", iamEndpoint, userManagementEndpoint)
+}
+
+// Init indicates an expected call of Init.
+func (mr *MockiamHelperMockRecorder) Init(iamEndpoint, userManagementEndpoint interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockiamHelper)(nil).Init), iamEndpoint, userManagementEndpoint)
+}
+
+// ObtainToken mocks base method.
 func (m *MockiamHelper) ObtainToken(apiKey string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ObtainToken", apiKey)
@@ -43,13 +110,13 @@ func (m *MockiamHelper) ObtainToken(apiKey string) (string, error) {
 	return ret0, ret1
 }
 
-// ObtainToken indicates an expected call of ObtainToken
+// ObtainToken indicates an expected call of ObtainToken.
 func (mr *MockiamHelperMockRecorder) ObtainToken(apiKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObtainToken", reflect.TypeOf((*MockiamHelper)(nil).ObtainToken), apiKey)
 }
 
-// VerifyToken mocks base method
+// VerifyToken mocks base method.
 func (m *MockiamHelper) VerifyToken(ctx context.Context, token string) (*tokenInfo, *logical.Response) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyToken", ctx, token)
@@ -58,74 +125,8 @@ func (m *MockiamHelper) VerifyToken(ctx context.Context, token string) (*tokenIn
 	return ret0, ret1
 }
 
-// VerifyToken indicates an expected call of VerifyToken
+// VerifyToken indicates an expected call of VerifyToken.
 func (mr *MockiamHelperMockRecorder) VerifyToken(ctx, token interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyToken", reflect.TypeOf((*MockiamHelper)(nil).VerifyToken), ctx, token)
-}
-
-// CheckServiceIDAccount mocks base method
-func (m *MockiamHelper) CheckServiceIDAccount(iamToken, identifier, accountID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckServiceIDAccount", iamToken, identifier, accountID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckServiceIDAccount indicates an expected call of CheckServiceIDAccount
-func (mr *MockiamHelperMockRecorder) CheckServiceIDAccount(iamToken, identifier, accountID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckServiceIDAccount", reflect.TypeOf((*MockiamHelper)(nil).CheckServiceIDAccount), iamToken, identifier, accountID)
-}
-
-// CheckUserIDAccount mocks base method
-func (m *MockiamHelper) CheckUserIDAccount(iamToken, iamID, accountID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckUserIDAccount", iamToken, iamID, accountID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckUserIDAccount indicates an expected call of CheckUserIDAccount
-func (mr *MockiamHelperMockRecorder) CheckUserIDAccount(iamToken, iamID, accountID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckUserIDAccount", reflect.TypeOf((*MockiamHelper)(nil).CheckUserIDAccount), iamToken, iamID, accountID)
-}
-
-// CheckGroupMembership mocks base method
-func (m *MockiamHelper) CheckGroupMembership(groupID, iamID, iamToken string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckGroupMembership", groupID, iamID, iamToken)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CheckGroupMembership indicates an expected call of CheckGroupMembership
-func (mr *MockiamHelperMockRecorder) CheckGroupMembership(groupID, iamID, iamToken interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckGroupMembership", reflect.TypeOf((*MockiamHelper)(nil).CheckGroupMembership), groupID, iamID, iamToken)
-}
-
-// Init mocks base method
-func (m *MockiamHelper) Init() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Init")
-}
-
-// Init indicates an expected call of Init
-func (mr *MockiamHelperMockRecorder) Init() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockiamHelper)(nil).Init))
-}
-
-// Cleanup mocks base method
-func (m *MockiamHelper) Cleanup() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Cleanup")
-}
-
-// Cleanup indicates an expected call of Cleanup
-func (mr *MockiamHelperMockRecorder) Cleanup() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockiamHelper)(nil).Cleanup))
 }

--- a/path_config.go
+++ b/path_config.go
@@ -145,6 +145,14 @@ func (b *ibmCloudAuthBackend) pathConfigRead(ctx context.Context, req *logical.R
 		displayKey = redacted
 	}
 
+	if config.IAMEndpoint == "" {
+		config.IAMEndpoint = iamEndpointFieldDefault
+	}
+
+	if config.UserManagementEndpoint == "" {
+		config.IAMEndpoint = userMgmtEndpointDefault
+	}
+
 	resp := &logical.Response{
 		Data: map[string]interface{}{
 			apiKeyField:                 displayKey,
@@ -195,6 +203,14 @@ func (b *ibmCloudAuthBackend) getConfig(ctx context.Context, s logical.Storage) 
 	}
 	if config.Account == "" {
 		return nil, logical.ErrorResponse("no account ID was set in the configuration")
+	}
+
+	if config.IAMEndpoint == "" {
+		config.IAMEndpoint = iamEndpointFieldDefault
+	}
+
+	if config.UserManagementEndpoint == "" {
+		config.UserManagementEndpoint = userMgmtEndpointDefault
 	}
 
 	return config, nil

--- a/path_config_test.go
+++ b/path_config_test.go
@@ -2,7 +2,6 @@ package ibmcloudauth
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
@@ -46,6 +45,22 @@ func TestConfig_Write(t *testing.T) {
 			t.Fatal("the account_id field was not found in the read config")
 		}
 
+		keyVal, ok = resp.Data[iamEndpointField]
+		if !ok {
+			t.Fatal("the iam_endpoint field was not found in the read config")
+		}
+		if keyVal != iamEndpointFieldDefault {
+			t.Fatal("the iam_endpoint was not defaulted as expected")
+		}
+
+		keyVal, ok = resp.Data[userManagementEndpointField]
+		if !ok {
+			t.Fatal("the user_management_endpoint field was not found in the read config")
+		}
+		if keyVal != userMgmtEndpointDefault {
+			t.Fatal("the user_management_endpoint was not defaulted as expected")
+		}
+
 	} else {
 		t.Fatal("did not get a response from the read post-create")
 	}
@@ -63,16 +78,16 @@ func TestConfigDelete(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+	_, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.DeleteOperation,
-		Path:      fmt.Sprintf("config"),
+		Path:      "config",
 		Storage:   s,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	resp, err = b.HandleRequest(context.Background(), &logical.Request{
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ReadOperation,
 		Path:      "config",
 		Storage:   s,
@@ -89,7 +104,7 @@ func TestConfigDelete(t *testing.T) {
 func testConfigCreate(t *testing.T, b *ibmCloudAuthBackend, s logical.Storage, d map[string]interface{}) error {
 	resp, err := b.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.CreateOperation,
-		Path:      fmt.Sprintf("config"),
+		Path:      "config",
 		Data:      d,
 		Storage:   s,
 	})
@@ -100,4 +115,86 @@ func testConfigCreate(t *testing.T, b *ibmCloudAuthBackend, s logical.Storage, d
 		return resp.Error()
 	}
 	return nil
+}
+
+func TestConfig_WriteIAMEndpoint(t *testing.T) {
+	b, s := testBackend(t)
+
+	configData := map[string]interface{}{}
+	if err := testConfigCreate(t, b, s, configData); err == nil {
+		t.Fatal("expected error")
+	}
+
+	testEndpoint := "https://private.iam.cloud.ibm.com"
+	configData = map[string]interface{}{
+		apiKeyField:      "theAPIKey",
+		accountIDField:   "theAccount",
+		iamEndpointField: testEndpoint,
+	}
+	if err := testConfigCreate(t, b, s, configData); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config",
+		Storage:   s,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp != nil {
+		keyVal, ok := resp.Data[iamEndpointField]
+		if !ok {
+			t.Fatal("the iam_endpoint field was not found in the read config")
+		}
+		if keyVal != testEndpoint {
+			t.Fatal("the iam_endpoint was set as expected")
+		}
+
+	} else {
+		t.Fatal("did not get a response from the read post-create")
+	}
+}
+
+func TestConfig_WriteUserMgmtEndpoint(t *testing.T) {
+	b, s := testBackend(t)
+
+	configData := map[string]interface{}{}
+	if err := testConfigCreate(t, b, s, configData); err == nil {
+		t.Fatal("expected error")
+	}
+
+	testEndpoint := "https://private.user-management.cloud.ibm.com"
+	configData = map[string]interface{}{
+		apiKeyField:                 "theAPIKey",
+		accountIDField:              "theAccount",
+		userManagementEndpointField: testEndpoint,
+	}
+	if err := testConfigCreate(t, b, s, configData); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp, err := b.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      "config",
+		Storage:   s,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp != nil {
+		keyVal, ok := resp.Data[userManagementEndpointField]
+		if !ok {
+			t.Fatal("the user_management_endpoint field was not found in the read config")
+		}
+		if keyVal != testEndpoint {
+			t.Fatal("the user_management_endpoint was set as expected")
+		}
+
+	} else {
+		t.Fatal("did not get a response from the read post-create")
+	}
 }

--- a/path_login.go
+++ b/path_login.go
@@ -89,15 +89,21 @@ func (b *ibmCloudAuthBackend) pathAuthLogin(ctx context.Context, req *logical.Re
 		return nil, err
 	}
 
+	iam, resp := b.getIAMHelper(ctx, req.Storage)
+	if resp != nil {
+		b.Logger().Error("failed to retrieve an IAM helper", "error", resp.Error())
+		return resp, nil
+	}
+
 	if apiKey != "" {
-		callerToken, err = b.iamHelper.ObtainToken(apiKey)
+		callerToken, err = iam.ObtainToken(apiKey)
 		if err != nil {
 			b.Logger().Debug("obtain user token failed", "error", err)
 			return nil, logical.ErrPermissionDenied
 		}
 	}
 
-	callerTokenInfo, resp := b.iamHelper.VerifyToken(ctx, callerToken)
+	callerTokenInfo, resp := iam.VerifyToken(ctx, callerToken)
 	if resp != nil {
 		return resp, nil
 	}
@@ -108,7 +114,7 @@ func (b *ibmCloudAuthBackend) pathAuthLogin(ctx context.Context, req *logical.Re
 		return nil, logical.ErrPermissionDenied
 	}
 
-	err = b.verifyBoundEntities(adminToken, callerTokenInfo.Subject, callerTokenInfo.IAMid, role)
+	err = b.verifyBoundEntities(ctx, req.Storage, adminToken, callerTokenInfo.Subject, callerTokenInfo.IAMid, role)
 	if err != nil {
 		return nil, err
 	}
@@ -168,15 +174,21 @@ func (b *ibmCloudAuthBackend) pathLoginRenew(ctx context.Context, req *logical.R
 		return nil, err
 	}
 
+	iam, resp := b.getIAMHelper(ctx, req.Storage)
+	if resp != nil {
+		b.Logger().Error("failed to retrieve an IAM helper", "error", resp.Error())
+		return resp, nil
+	}
+
 	apiKeyRaw, ok := req.Auth.InternalData[apiKeyField]
 	if ok {
 		apiKey := apiKeyRaw.(string)
-		userToken, err := b.iamHelper.ObtainToken(apiKey)
+		userToken, err := iam.ObtainToken(apiKey)
 		if err != nil {
 			b.Logger().Debug("obtain user token failed", "error", err)
 			return logical.ErrorResponse("error reauthorizing with the token's stored API key, cannot renew"), nil
 		}
-		_, resp := b.iamHelper.VerifyToken(ctx, userToken)
+		_, resp := iam.VerifyToken(ctx, userToken)
 		if resp != nil {
 			return resp, nil
 		}
@@ -187,25 +199,32 @@ func (b *ibmCloudAuthBackend) pathLoginRenew(ctx context.Context, req *logical.R
 		return nil, logical.ErrPermissionDenied
 	}
 
-	err = b.verifyBoundEntities(adminToken, subject, iamID, role)
+	err = b.verifyBoundEntities(ctx, req.Storage, adminToken, subject, iamID, role)
 	if err != nil {
 		return nil, err
 	}
-	resp := &logical.Response{Auth: req.Auth}
+	resp = &logical.Response{Auth: req.Auth}
 	resp.Auth.TTL = role.TokenTTL
 	resp.Auth.MaxTTL = role.TokenMaxTTL
 	resp.Auth.Period = role.TokenPeriod
 	return resp, nil
 }
 
-func (b *ibmCloudAuthBackend) verifyBoundEntities(accessToken, subject, iamID string, role *ibmCloudRole) error {
+func (b *ibmCloudAuthBackend) verifyBoundEntities(ctx context.Context, stg logical.Storage, accessToken, subject, iamID string, role *ibmCloudRole) error {
 	// Check for the subject in the bound subject list
 	if !strutil.StrListContains(role.BoundSubscriptionsIDs, subject) {
 		var err error
+
+		iam, resp := b.getIAMHelper(ctx, stg)
+		if resp != nil {
+			b.Logger().Error("failed to retrieve an IAM helper", "error", resp.Error())
+			return resp.Error()
+		}
+
 		// Check the access groups next
 		subjectFoundInGroup := false
 		for _, group := range role.BoundAccessGroupIDs {
-			if err = b.iamHelper.CheckGroupMembership(group, iamID, accessToken); err == nil {
+			if err = iam.CheckGroupMembership(group, iamID, accessToken); err == nil {
 				subjectFoundInGroup = true
 				break
 			}
@@ -226,10 +245,16 @@ func (b *ibmCloudAuthBackend) verifyAccountAccess(ctx context.Context, stg logic
 		return errors.New("no configuration was found")
 	}
 
+	iam, resp := b.getIAMHelper(ctx, stg)
+	if resp != nil {
+		b.Logger().Error("failed to retrieve an IAM helper", "error", resp.Error())
+		return resp.Error()
+	}
+
 	if subjectType == serviceIDSubjectType {
-		return b.iamHelper.CheckServiceIDAccount(adminToken, identifier, config.Account)
+		return iam.CheckServiceIDAccount(adminToken, identifier, config.Account)
 	} else {
-		return b.iamHelper.CheckUserIDAccount(adminToken, iamID, config.Account)
+		return iam.CheckUserIDAccount(adminToken, iamID, config.Account)
 	}
 }
 

--- a/path_login.go
+++ b/path_login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/cidrutil"
 	"github.com/hashicorp/vault/sdk/helper/policyutil"
@@ -136,6 +137,9 @@ func (b *ibmCloudAuthBackend) pathAuthLogin(ctx context.Context, req *logical.Re
 
 func (b *ibmCloudAuthBackend) pathLoginRenew(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	roleName, ok := req.Auth.Metadata[roleField]
+	if !ok {
+		return logical.ErrorResponse("an error occurred retrieving role name metadata"), nil
+	}
 	if roleName == "" {
 		return logical.ErrorResponse("role name metadata not associated with auth token, invalid"), nil
 	}


### PR DESCRIPTION
Add support for IBM Cloud IAM and user management private endpoints. This support adds a new optional configuration fields for the endpoints which allows the plugin to use non-public endpoint URLs for the API requests.